### PR TITLE
Related-website-sets: Add Tolteck

### DIFF
--- a/related_website_sets.JSON
+++ b/related_website_sets.JSON
@@ -727,6 +727,16 @@
        "https://radio2.be": "sub brand site",
        "https://radio1.be": "sub brand site"
     }
- }
+ },
+ {
+    "contact": "support@tolteck.com",
+    "primary": "https://tolteck.com",
+    "associatedSites": [
+      "https://tolteck.app"
+    ],
+    "rationaleBySite": {
+      "https://tolteck.app": "Tolteck application"
+    }
+  }
   ]
 }


### PR DESCRIPTION
Once this PR reviewed and validated by the team, it should be submitted to the [Chrome's related-website-sets repo](https://github.com/GoogleChrome/related-website-sets).

This cannot be merged until the checks pass:
```bash
python check_sites.py --primaries=https://tolteck.com
```

For now (as April the 22th) the checks output the following:

```bash
Experienced an error when trying to access https://tolteck.app/.well-known/related-website-set.json; error was: Expecting value: line 1 column 1 (char 0)
Experienced an error when trying to access https://www.tolteck.com/.well-known/related-website-set.json; error was: HTTP Error 404: Not Found
```
